### PR TITLE
Don't use `postinstall`, use `prepare`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "eslint-config-andrewaylett",
       "version": "2.1.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@tsconfig/node16": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,8 @@
     "pretest": "npm run lint",
     "lint:fix": "npm run lint -- --fix",
     "dev": "npm run lint:fix && npm run build",
-    "prepublishOnly": "npm run build",
     "clean": "rm -rf ./dist ./build",
-    "postinstall": "npm run clean"
+    "prepare": "npm run clean && npm run buildonly"
   },
   "prettier": {
     "semi": true,


### PR DESCRIPTION
Following the recommendations in
https://docs.npmjs.com/cli/v8/using-npm/scripts#best-practices we don't want to use `install`-type scripts.  It seems that NPM considers a `postinstall` to still be a variety of install script, as can be seen by looking at the diff of `package-lock.json`.

I'm hoping this helps us avoid removing `/dist/` before publishing.

Signed-off-by: Andrew Aylett <andrew@aylett.co.uk>